### PR TITLE
Update this namelist to add wif_input_opt

### DIFF
--- a/Namelists/weekly/em_real/MPI/namelist.input.65DF
+++ b/Namelists/weekly/em_real/MPI/namelist.input.65DF
@@ -55,6 +55,7 @@
  smooth_option                       = 0
  use_adaptive_time_step              = .FALSE.
  step_to_output_time                 = .FALSE.
+ wif_input_opt                       = 1
  /
 
  &physics


### PR DESCRIPTION
wif_input_opt is required in 4.4 to input aerosol data.