### PR TITLE
Update this namelist with wif_input_opt

### DIFF
--- a/Namelists/weekly/em_real/MPI/namelist.input.rap
+++ b/Namelists/weekly/em_real/MPI/namelist.input.rap
@@ -55,6 +55,7 @@
  smooth_option                       = 0
  use_adaptive_time_step              = .FALSE.
  step_to_output_time                 = .FALSE.
+ wif_input_opt                       = 1
  /
 
  &physics


### PR DESCRIPTION
Code in v4.4 requires the use of this namelist: wif_input_opt. Same as for namelist.input.65DF.