### PR TITLE
Update namelist.input.65DF in this em_realF dir

### DIFF
--- a/Namelists/weekly/em_realF/MPI/namelist.input.65DF
+++ b/Namelists/weekly/em_realF/MPI/namelist.input.65DF
@@ -55,6 +55,7 @@
  smooth_option                       = 0
  use_adaptive_time_step              = .FALSE.
  step_to_output_time                 = .FALSE.
+ wif_input_opt                       = 1
  /
 
  &physics


### PR DESCRIPTION
Code in v4.4 requires the use of this namelist: wif_input_opt. Same as for namelist.input.65DF.