### PR TITLE
update python script to ignore bool warning

### DIFF
--- a/rd_l2_norm.py
+++ b/rd_l2_norm.py
@@ -2,6 +2,9 @@ from netCDF4 import Dataset
 import numpy as np
 import sys
 
+from warnings import filterwarnings
+filterwarnings(action='ignore', category=DeprecationWarning, message='`np.bool` is a deprecated alias')
+
 o = Dataset(str(sys.argv[1]))
 
 list_of_vars = o.variables.keys()


### PR DESCRIPTION
Python is updated to V3.8 for regression testing and now when running a WRF test, a warning message is printed out:
`/wrf/rd_l2_norm.py:11: DeprecationWarning: `np.bool` is a deprecated alias for the builtin `bool`. To silence this warning, use `bool` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.bool_` here.`
This is not an error, but may cause confusion for some. To remove this error, the file rd_l2_norm.py has been modified so the warning will be ignored. 

